### PR TITLE
autogen.sh: add gnulib modules for Solaris

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ libpaxutils_la_SOURCES = \
 	paxmacho.c \
 	security.c \
 	xfuncs.c
-LDADD = libpaxutils.la $(top_builddir)/autotools/gnulib/libgnu.a
+LDADD = libpaxutils.la $(top_builddir)/autotools/gnulib/libgnu.a $(LIB_EACCESS)
 
 bin_SCRIPTS = lddtree symtree
 bin_PROGRAMS = scanelf dumpelf pspax scanmacho

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,6 +13,7 @@ fi
 PATH=/usr/local/src/gnu/gnulib:${PATH}
 mods="
 	alloca
+	euidaccess
 	faccessat
 	fdopendir
 	fstatat
@@ -25,6 +26,7 @@ mods="
 	readlinkat
 	renameat
 	stat-time
+	stpcpy
 	strcasestr-simple
 	strncat
 	symlinkat


### PR DESCRIPTION
Need gnulib modules stpcpy, euidaccess for Solaris 10, where euidaccess
uses eaccess when available, probably via LIB_EACCESS.