### PR TITLE
scanelf.c: fix quiet output for musl's libc.so

### DIFF
--- a/scanelf.c
+++ b/scanelf.c
@@ -1553,7 +1553,7 @@ static int scanelf_elfobj(elfobj *elf)
 		xchrcat(&out_buffer, ' ', &out_len);
 		xstrcat(&out_buffer, elf->filename, &out_len);
 	}
-	if (!be_quiet || (be_quiet && FOUND_SOMETHING())) {
+	if (found_file || !be_quiet || (be_quiet && FOUND_SOMETHING())) {
 		puts(out_buffer);
 		fflush(stdout);
 	}


### PR DESCRIPTION
Fix this command to output musl's libc.so:
```
$ scanelf -yqRBF '%a;%p;%S;%r;%n' /usr/lib/libc.so
EM_X86_64;/usr/lib/libc.so;;;
```
Bug: https://bugs.gentoo.org/721336
Signed-off-by: Zac Medico <zmedico@gentoo.org>