### PR TITLE
pspax: replace deprecated capgetp()

### DIFF
--- a/pspax.c
+++ b/pspax.c
@@ -413,7 +413,7 @@ static void pspax(const char *find_name)
 
 		/* this is a non-POSIX function */
 		caps = NULL;
-		WRAP_SYSCAP(capgetp(pfd, cap_d));
+		WRAP_SYSCAP(cap_d = cap_get_pid(pid));
 		WRAP_SYSCAP(caps = cap_to_text(cap_d, &length));
 
 		if (pwd && strlen(pwd->pw_name) >= 8)


### PR DESCRIPTION
This doesn't actually show any process having any capabilities for some
reason; everything lists "=ep".  Not sure what's going on there, but
capgetp() is marked as deprecated anyways, and cap_get_pid() seems to
actually work correctly.

Signed-off-by: David Lamparter <equinox@diac24.net>