### PR TITLE
meson: include generated man pages in dist tarballs

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -8,8 +8,7 @@ on:
     branches: [master, gh-actions]
     tags: [v*]
   pull_request:
-    types: [opened]
-    branches: [master]
+    types: [created, opened, edited]
 
 jobs:
   make:

--- a/man/meson.build
+++ b/man/meson.build
@@ -18,20 +18,31 @@ pages = [
     'dumpelf.docbook', 'pspax.docbook', 'scanelf.docbook', 'scanmacho.docbook'
 ]
 
+fs = import('fs')
+
 out_pages = []
+generated_man_pages_exist = true
 foreach page : pages
-  out_pages += page.replace('.docbook', '.1')
+  man_page_name = page.replace('.docbook', '.1')
+  out_pages += man_page_name
+  if not fs.exists(man_page_name)
+      generated_man_pages_exist = false
+  endif
 endforeach
 
-custom_target('docbook_to_man',
-  command : [
-    xmlto, '-x', files('custom.xsl'), '--skip-validation',
-    '-o', meson.current_build_dir(), 'man', book
-  ],
-  input : [
-    'pax-utils.docbook.in', 'custom.xsl', 'fragment/reftail',
-  ] + pages,
-  output : out_pages,
-  install : true,
-  install_dir : get_option('mandir') / 'man1'
-)
+if generated_man_pages_exist
+  install_man(out_pages)
+else
+  custom_target('docbook_to_man',
+    command : [
+      xmlto, '-x', files('custom.xsl'), '--skip-validation',
+      '-o', meson.current_build_dir(), 'man', book
+    ],
+    input : [
+      'pax-utils.docbook.in', 'custom.xsl', 'fragment/reftail',
+    ] + pages,
+    output : out_pages,
+    install : true,
+    install_dir : get_option('mandir') / 'man1'
+  )
+endif

--- a/meson-build-dist-man.sh
+++ b/meson-build-dist-man.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# This script should be invoked by meson itself (via 'meson dist')
+# See https://github.com/mesonbuild/meson/issues/2166 and more specifically,
+# https://github.com/mesonbuild/meson/issues/2166#issuecomment-629696911.
+set -eu
+
+cd "${MESON_DIST_ROOT}"
+mkdir build
+meson setup build -Dbuild_manpages=enabled
+meson compile -C build
+cp build/man/* man/
+rm -rf build

--- a/meson.build
+++ b/meson.build
@@ -138,6 +138,8 @@ install_data('symtree.sh',
 
 subdir('man')
 
+meson.add_dist_script('meson-build-dist-man.sh')
+
 do_tests = get_option('tests')
 if do_tests
   subdir('tests/lddtree')


### PR DESCRIPTION
  meson: include generated man pages in dist tarballs

  Meson doesn't have an idiomatic way of doing this (for once!)
  so we have to (per Eli Schwartz, thanks!) have:
  1. a dist script which duplicates the build rule;
  2. some meson.build if/else logic with fs.exists() to prefer the built manpage when using tarballs

  Sadly, still can't easily regenerate man pages if
  you apply a patch downstream though.

  We use Michael Stapelberg's example from the linked bug as inspiration.

  Bug: https://github.com/mesonbuild/meson/issues/2166
  Reported-by: psykose <alice@ayaya.dev>
  Thanks-to: Eli Schwartz <eschwartz@archlinux.org>
  Signed-off-by: Sam James <sam@gentoo.org>