### PR TITLE
scanelf: allow user to choose whether to scan .symtab or .dynsym

### DIFF
--- a/paxelf.h
+++ b/paxelf.h
@@ -43,6 +43,14 @@ typedef struct {
 #define DYN64(ptr) ((Elf64_Dyn *)(ptr))
 #define SYM32(ptr) ((Elf32_Sym *)(ptr))
 #define SYM64(ptr) ((Elf64_Sym *)(ptr))
+#define VERDEF32(ptr) ((Elf32_Verdef *)(ptr))
+#define VERDEF64(ptr) ((Elf64_Verdef *)(ptr))
+#define VERDAUX32(ptr) ((Elf32_Verdaux *)(ptr))
+#define VERDAUX64(ptr) ((Elf64_Verdaux *)(ptr))
+#define VERNEED32(ptr) ((Elf32_Verneed *)(ptr))
+#define VERNEED64(ptr) ((Elf64_Verneed *)(ptr))
+#define VERNAUX32(ptr) ((Elf32_Vernaux *)(ptr))
+#define VERNAUX64(ptr) ((Elf64_Vernaux *)(ptr))
 
 #define VALID_RANGE(elf, offset, size) \
 	((uint64_t)(size) <= (uint64_t)elf->len && \

--- a/tests/scanelf/dotest
+++ b/tests/scanelf/dotest
@@ -5,7 +5,7 @@
 #
 # simple scanelf symbol checks
 #
-${MESON_EXE_WRAPPER} "${builddir}/scanelf" -qsmain -F'%s %f' \
+${MESON_EXE_WRAPPER} "${builddir}/scanelf" -qsmain -F'%s %f' -Hsymtab \
 	"${builddir}"/scanelf > "${builddir}"/scanelf.simple
 testit scanelf.simple tests/scanelf/scanelf.simple.good
 


### PR DESCRIPTION
This pull request adds a new command line switch (`-H`/`--how`) that
allows the user to select whether `scanelf` should look for symbols in
`.symtab` or `.dynsym`.

This is done because the the sections contain different sets
of symbols (which somewhat intersect), and the names for the symbols
differ (`.symtab` includes the version suffix within the symbol itself),
which would cause `scanelf` to behave differently before and after
stripping the executable.

Additionally, it adds two modes of looking for symbols in `.dynsym`:
 - unversioned - look at the `.dynsym` entries as they are,
 - versioned - also look at `.gnu.version` to figure out the symbol
   version, and suffix the symbol name with it before matching,
   emulating the behavior of `.symtab`.

Note that this does not handle the case where the dynamic section needs
to be scanned to find the version information, as that case appears to
not be fully functional anyway (no `DT_GNU_HASH` support, and most ELFs
these days don't have `DT_HASH`). Consider it a TODO if need be :^).

Fixes bug 847493.

Thanks to @ArsenArsen for the idea for the fix. 