### PR TITLE
Fix fuzz-dumpelf test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -166,6 +166,12 @@ if do_tests and get_option('use_fuzzing')
       link_args : fuzz_flags,
       install : false
     )
-    test('fuzz-dumpelf', dumpelf_fuzzer)
+    test('fuzz-dumpelf', dumpelf_fuzzer,
+      args : [
+        '-close_fd_mask=3',
+        '-max_total_time=10',
+        '-print_final_stats',
+      ]
+    )
   endif
 endif

--- a/security.c
+++ b/security.c
@@ -46,6 +46,10 @@
 # undef WANT_SECCOMP
 #endif
 
+#if PAX_UTILS_LIBFUZZ
+# undef WANT_SECCOMP
+#endif
+
 static int ns_unshare(int flags)
 {
 	int flag, ret = 0;


### PR DESCRIPTION
Hello,

Not sure why, but the `dumpelf.fuzz` fuzzer fails when it's calling `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...)` at `security_init`. So I suggest disabling `seccomp` for fuzzy testing.

Also, in order to not run indefinitely, the fuzzer must be executed with some reasonable [options](https://releases.llvm.org/14.0.0/docs/LibFuzzer.html#options).

Please note that tests with enabled `address` sanitizer still fail and require further investigation.

By the way, I've created a `Dockerfile` to investigate this issue locally.
https://github.com/Jamim/pax-utils/blob/feature/dockerfile/Dockerfile
```bash
docker buildx build . -t pax-utils
docker run --rm -it pax-utils
```

Best regards!