### PR TITLE
Memory leak and build fixes

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -19,7 +19,7 @@ fs = import('fs')
 out_pages = []
 generated_man_pages_exist = true
 foreach page : pages
-  man_page_name = page.replace('.docbook', '.1')
+  man_page_name = page.split('.')[0] + '.1'
   out_pages += man_page_name
   if not fs.exists(man_page_name)
       generated_man_pages_exist = false

--- a/pspax.c
+++ b/pspax.c
@@ -345,8 +345,6 @@ static void pspax(const char *find_name)
 	int pfd;
 	WRAP_SYSCAP(ssize_t length; cap_t cap_d;)
 
-	WRAP_SYSCAP(cap_d = cap_init());
-
 	dir = opendir(PROC_DIR);
 	if (dir == NULL || chdir(PROC_DIR))
 		errp(PROC_DIR);
@@ -438,7 +436,8 @@ static void pspax(const char *find_name)
 				print_executable_mappings(pfd);
 		}
 
-		WRAP_SYSCAP(if (caps) cap_free(caps));
+		WRAP_SYSCAP(cap_free(cap_d));
+		WRAP_SYSCAP(cap_free(caps));
 
  next_pid:
 		close(pfd);


### PR DESCRIPTION
The addition of a unit test for `pspax` in https://github.com/gentoo/pax-utils/commit/66417851bbfc2266513774e59aa32b36469a756b made the CI discover its memory leaks. Fix them.

Also add a commit lowering the minimal meson version required to build. Debian is always a few versions behind :/