### PR TITLE
lddtree.sh: Add an "ldd-mode" for when the command is executed as *ldd 

### DIFF
--- a/lddtree.py
+++ b/lddtree.py
@@ -852,12 +852,17 @@ def GetParser() -> argparse.ArgumentParser:
         help="Search for all files/dependencies in ROOT",
     )
     group.add_argument(
+        "--auto-root",
+        action="store_true",
+        help="Automatically prefix input ELFs with ROOT",
+    )
+    group.add_argument(
         "--no-auto-root",
         dest="auto_root",
         action="store_false",
-        default=True,
-        help="Do not automatically prefix input ELFs with ROOT",
+        help=argparse.SUPPRESS,
     )
+    group.set_defaults(auto_root=False)
     group.add_argument(
         "-C",
         "--cwd",

--- a/lddtree.sh
+++ b/lddtree.sh
@@ -19,7 +19,7 @@ usage() {
 	  -a              Show all duplicated dependencies
 	  -x              Run with debugging
 	  -R <root>       Use this ROOT filesystem tree
-	  --no-auto-root  Do not automatically prefix input ELFs with ROOT
+	  --auto-root     Automatically prefix input ELFs with ROOT
 	  -l              Display output in a flat format
 	  -h              Show this help output
 	  -V              Show version information
@@ -226,7 +226,7 @@ if [[ $1 != "/../..source.lddtree" ]] ; then
 SHOW_ALL=false
 SET_X=false
 LIST=false
-AUTO_ROOT=true
+AUTO_ROOT=false
 LDD_MODE=false
 
 [[ ${argv0} = *ldd ]] && LDD_MODE=true
@@ -241,6 +241,7 @@ while getopts haxVR:l-:  OPT ; do
 	l) LIST=true LDD_MODE=false;;
 	-) # Long opts ftw.
 		case ${OPTARG} in
+		auto-root) AUTO_ROOT=true;;
 		no-auto-root) AUTO_ROOT=false;;
 		*) usage 1;;
 		esac

--- a/meson.build
+++ b/meson.build
@@ -116,18 +116,25 @@ executable('scanmacho',
   install : true
 )
 
+install_data('lddtree.sh',
+  install_dir : get_option('bindir')
+)
 lddtree_impl = get_option('lddtree_implementation')
 if lddtree_impl != 'none'
   if lddtree_impl == 'python'
+    install_data('lddtree.py',
+      install_dir : get_option('bindir')
+    )
     suffix = '.py'
   else
     suffix = '.sh'
   endif
-  install_data('lddtree' + suffix,
-    rename : 'lddtree',
+  install_symlink('lddtree',
+    pointing_to : 'lddtree' + suffix,
     install_dir : get_option('bindir')
   )
 endif
+
 install_data('symtree.sh',
   rename : 'symtree',
   install_dir : get_option('bindir')


### PR DESCRIPTION
Dracut needs ldd to identify which libraries it needs to pull into the initrd. The regular ldd does not work across architectures though, so it suggests using [this gist](https://gist.github.com/jerome-pouiller/c403786c1394f53f44a3b61214489e6f), which is based on a script from crosstool-ng. I suggested adding this to Gentoo's crossdev but there was little appetite to add yet another ldd implementation.

lddtree.sh almost outputs what we need, the main issue being that it includes the file being examined, even when it is the only file being examined. I decided to add an "ldd-mode" to make the output more like regular ldd when it is executed as *ldd. The intention is to install a symlink to it with crossdev. I had to restructure the code a bit to ensure it was still readable after adding a third output format.

lddtree.sh currently doesn't get installed when the Python implementation is chosen, which would make things awkward for crossdev. I have therefore made Meson install lddtree.sh unconditionally, adding an lddtree symlink pointing to the chosen implementation instead.

Both lddtree implementations enable the auto-root feature by default. This breaks Dracut as it passes regular rooted paths to ldd, meaning that /foo/bin/ls becomes /foo/foo/bin/ls. I don't want to have to create a wrapper to disable this option, and it seems like quite a counter-intuitive feature anyway, so I have now disabled it by default. Hopefully this isn't controversial. I can't see any use of lddtree by packages at build time or runtime.