### PR TITLE
paxelf: use unsigned chars for data by default

### DIFF
--- a/dumpelf.c
+++ b/dumpelf.c
@@ -366,7 +366,7 @@ static void dump_shdr(const elfobj *elf, const void *shdr_void, size_t shdr_cnt,
 	/* Make sure the string is valid. */
 	if ((const void *)section_name >= elf->data_end)
 		section_name = "<corrupt>";
-	else if (memchr(section_name, 0, elf->len - (section_name - elf->data)) == NULL)
+	else if (memchr(section_name, 0, elf->len - (section_name - elf->cdata)) == NULL)
 		section_name = "<corrupt>";
 
 #define DUMP_SHDR(B) \

--- a/paxelf.c
+++ b/paxelf.c
@@ -812,7 +812,7 @@ const void *elf_findsecbyname(const elfobj *elf, const char *name)
 	for (i = 0; i < shnum; ++i) { \
 		offset = EGET(strtbl->sh_offset) + EGET(shdr[i].sh_name); \
 		if (offset >= (Elf ## B ## _Off)elf->len) continue; \
-		shdr_name = elf->data + offset; \
+		shdr_name = elf->cdata + offset; \
 		if (!strcmp(shdr_name, name)) { \
 			if (ret) warnf("Multiple '%s' sections !?", name); \
 			ret = &shdr[i]; \

--- a/paxelf.h
+++ b/paxelf.h
@@ -18,7 +18,8 @@ typedef struct {
 	void *_data;
 	union {
 		const void *ehdr, *vdata;
-		const char *data;
+		const char *cdata;
+		const unsigned char *data;
 		uintptr_t udata;
 	};
 	const void *data_end;

--- a/scanelf.c
+++ b/scanelf.c
@@ -486,7 +486,7 @@ static const char *scanelf_file_phdr(elfobj *elf, char *found_phdr, char *found_
 			offset = EGET(strtbl->sh_offset) + EGET(shdr[i].sh_name); \
 			if (!VALID_RANGE(elf, offset, sizeof(NOTE_GNU_STACK))) \
 				continue; \
-			if (!strcmp(elf->data + offset, NOTE_GNU_STACK)) { \
+			if (!strcmp(elf->cdata + offset, NOTE_GNU_STACK)) { \
 				if (multi_stack++) warnf("%s: multiple .note.GNU-stack's !?", elf->filename); \
 				if (file_matches_list(elf->filename, qa_execstack)) \
 					continue; \
@@ -723,7 +723,7 @@ static const char *scanelf_file_textrels(elfobj *elf, char *found_textrels, char
 			printf(" in "); \
 			if (func && func->st_name) { \
 				if (strtab) { \
-					const char *func_name = elf->data + EGET(strtab->sh_offset) + EGET(func->st_name); \
+					const char *func_name = elf->cdata + EGET(strtab->sh_offset) + EGET(func->st_name); \
 					if (r_offset > EGET(func->st_size)) \
 						printf("(optimized out: previous %s)", func_name); \
 					else \
@@ -826,7 +826,7 @@ static void scanelf_file_rpath(elfobj *elf, char *found_rpath, char **ret, size_
 		offset = EGET(strtab->sh_offset) + EGET(dyn->d_un.d_ptr); \
 		if (offset < (Elf ## B ## _Off)elf->len) { \
 			if (*r) warn("ELF has multiple %s's !?", get_elfdtype(word)); \
-			*r = elf->data + offset; \
+			*r = elf->cdata + offset; \
 			/* cache the length in case we need to nuke this section later on */ \
 			if (fix_elf) \
 				offset = strlen(*r); \
@@ -977,7 +977,7 @@ static const char *scanelf_file_needed_lib(elfobj *elf, char *found_needed, char
 			Elf ## B ## _Off offset = EGET(strtab->sh_offset) + EGET(dyn->d_un.d_ptr); \
 			if (offset >= (Elf ## B ## _Off)elf->len) \
 				continue; \
-			needed = elf->data + offset; \
+			needed = elf->cdata + offset; \
 			if (op == 0) { \
 				/* -n -> print all entries */ \
 				if (!be_wewy_wewy_quiet) { \
@@ -1052,7 +1052,7 @@ static const char *scanelf_file_interp(elfobj *elf, char *found_interp)
 
 	/* Validate the pointer even if we don't use it in output */
 	if (offset && offset <= (uint64_t)elf->len) {
-		const char *interp = elf->data + offset;
+		const char *interp = elf->cdata + offset;
 
 		/* If it isn't a C pointer, it's garbage */
 		if (memchr(interp, 0, elf->len - offset)) {
@@ -1125,7 +1125,7 @@ static const char *scanelf_file_soname(elfobj *elf, char *found_soname)
 			Elf ## B ## _Off offset = EGET(strtab->sh_offset) + EGET(dyn->d_un.d_ptr); \
 			if (offset >= (Elf ## B ## _Off)elf->len) \
 				continue; \
-			soname = elf->data + offset; \
+			soname = elf->cdata + offset; \
 			*found_soname = 1; \
 			return (be_wewy_wewy_quiet ? NULL : soname); \
 		} \
@@ -1326,7 +1326,7 @@ static char *scanelf_file_sym(elfobj *elf, char *found_sym)
 			goto break_out;	\
 		if (sym->st_name) { \
 			/* make sure the symbol name is in acceptable memory range */ \
-			symname = elf->data + EGET(strtab->sh_offset) + EGET(sym->st_name); \
+			symname = elf->cdata + EGET(strtab->sh_offset) + EGET(sym->st_name); \
 			if (EGET(sym->st_name) >= (uint64_t)elf->len || \
 			    EGET(strtab->sh_offset) + EGET(sym->st_name) >= (uint64_t)elf->len || \
 			    !memchr(symname, 0, elf->len - EGET(strtab->sh_offset) + EGET(sym->st_name))) \


### PR DESCRIPTION
Fixes OSABI STANDALONE not detected when char is signed.