### PR TITLE
symtree.sh: add definition for missing function 'error'

### DIFF
--- a/symtree.sh
+++ b/symtree.sh
@@ -15,6 +15,12 @@ usage() {
 	exit ${1:-0}
 }
 
+error() {
+	echo "${argv0}: $*" 1>&2
+	ret=1
+	return 1
+}
+
 sym_list() {
 	# with large strings, bash is much slower than sed
 	local type=$1; shift


### PR DESCRIPTION
Without the 'error' function, this script will not exit failure on files that do not exist:

    $ ./symtree.sh asdf
    ./symtree.sh: line 88: error: command not found
    $ echo $?
    0

The error function is copied from lddtree.sh